### PR TITLE
[api] implement progression bulk POSTs

### DIFF
--- a/apps/api/src/routes/progression.ts
+++ b/apps/api/src/routes/progression.ts
@@ -19,7 +19,6 @@ import {
 	BulkIdsRequest,
 	CheerPlayerRequest,
 	CheerPlayerResponse,
-	SetSelectedCheerRequest,
 	form,
 	idParam,
 	intQuery,
@@ -27,6 +26,7 @@ import {
 	JsonArray,
 	ProgressionDto,
 	ReputationDto,
+	SetSelectedCheerRequest,
 	UNAUTHORIZED_RESPONSE,
 } from '../openapi'
 import {
@@ -463,29 +463,25 @@ export const progressionRoutes = new Hono<App>({ strict: false })
 		describeRoute({
 			tags: ['Progression'],
 			summary: 'Progressions in bulk (v1)',
-			description: 'No progression is stored yet, so this is an empty list.',
+			description:
+				'One progression per requested id, in request order. Players without stored ' +
+				'progression receive the level 1 / 0 XP default.',
 			requestBody: BULK_ID_BODY,
-			responses: { 200: json(JsonArray, 'An empty list') },
+			responses: { 200: json(ProgressionDto.array(), 'One progression per requested id') },
 		}),
-		async (c) => {
-			await parseFormIds(c) // TODO: query PlayerProgressions for these ids
-			return c.json([])
-		}
+		async (c) => c.json(await getProgressions(c.env.DB, await parseFormIds(c)))
 	)
-	// v2 is identical to v1 — same form-id parse + PlayerProgressions query.
+	// v2 is identical to v1 — same form-id parse and progression lookup.
 	.post(
 		'/api/players/v2/progression/bulk',
 		describeRoute({
 			tags: ['Progression'],
 			summary: 'Progressions in bulk (v2)',
-			description: 'Identical to v1 — same ids in, same empty list out.',
+			description: 'Identical to v1 — same ids in, same progression records out.',
 			requestBody: BULK_ID_BODY,
-			responses: { 200: json(JsonArray, 'An empty list') },
+			responses: { 200: json(ProgressionDto.array(), 'One progression per requested id') },
 		}),
-		async (c) => {
-			await parseFormIds(c) // TODO: query PlayerProgressions for these ids
-			return c.json([])
-		}
+		async (c) => c.json(await getProgressions(c.env.DB, await parseFormIds(c)))
 	)
 	// The 2023 client calls this as a GET with repeated `id` query params.
 	// Return a default progression per requested id.
@@ -509,15 +505,12 @@ export const progressionRoutes = new Hono<App>({ strict: false })
 			tags: ['Progression'],
 			summary: 'Progressions in bulk (unversioned path)',
 			description:
-				'An older unversioned path some client builds still call. Same empty answer as ' +
-				'the versioned POST forms.',
+				'An older unversioned path some client builds still call. It serves the same ' +
+				'progression records as the versioned POST forms.',
 			requestBody: BULK_ID_BODY,
-			responses: { 200: json(JsonArray, 'An empty list') },
+			responses: { 200: json(ProgressionDto.array(), 'One progression per requested id') },
 		}),
-		async (c) => {
-			await parseFormIds(c) // TODO: query PlayerProgressions for these ids
-			return c.json([])
-		}
+		async (c) => c.json(await getProgressions(c.env.DB, await parseFormIds(c)))
 	)
 
 	// The progression events running right now — the limited-time XP events the client shows

--- a/apps/api/src/test/integration/api.test.ts
+++ b/apps/api/src/test/integration/api.test.ts
@@ -922,12 +922,38 @@ describe('public endpoints', () => {
 		expect(applyLevelUps(1, 9)).toEqual({ level: 1, xp: 9 })
 	})
 
-	test('POST /api/players/v2/progression/bulk returns an array', async () => {
-		const res = await exports.default.fetch(`${ORIGIN}/api/players/v2/progression/bulk`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new URLSearchParams({ Ids: '1,2,3' }),
-		})
+	test.each([
+		['/api/players/v1/progression/bulk', 4301, 4401],
+		['/api/players/v2/progression/bulk', 4302, 4402],
+		['/api/v1/progression/bulk', 4303, 4403],
+	])(
+		'POST %s returns stored and default progression in request order',
+		async (path, storedId, defaultId) => {
+			await addXp(env.DB, storedId, 25)
+			const body = new URLSearchParams()
+			body.append('Ids', String(defaultId))
+			body.append('Ids', `${storedId},${defaultId}`)
+
+			const res = await exports.default.fetch(`${ORIGIN}${path}`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+				body,
+			})
+			expect(res.status).toBe(200)
+			expect(await res.json()).toEqual([
+				{ PlayerId: defaultId, Level: 1, XP: 0 },
+				{ PlayerId: storedId, Level: 3, XP: 5 },
+				{ PlayerId: defaultId, Level: 1, XP: 0 },
+			])
+		}
+	)
+
+	test.each([
+		'/api/players/v1/progression/bulk',
+		'/api/players/v2/progression/bulk',
+		'/api/v1/progression/bulk',
+	])('POST %s returns [] without ids', async (path) => {
+		const res = await exports.default.fetch(`${ORIGIN}${path}`, { method: 'POST' })
 		expect(res.status).toBe(200)
 		expect(await res.json()).toEqual([])
 	})


### PR DESCRIPTION
## Summary
- implement stored progression lookup for all three bulk POST routes
- preserve requested ordering and duplicate IDs
- return level 1 / 0 XP defaults for players without stored progression
- update OpenAPI descriptions and response schemas
- add regression tests covering stored values, defaults, repeated IDs, and empty input

## Verification
- Type-check passed
- Lint passed
- API integration tests: 299 passed