### PR TITLE
[api] implement inventions from creators feed

### DIFF
--- a/apps/api/src/inventions-db.ts
+++ b/apps/api/src/inventions-db.ts
@@ -565,6 +565,40 @@ export async function getInventionsByCreator(
 }
 
 /**
+ * Published inventions from several creators — the `v1/fromcreators` shelf used for a
+ * creator list and for accounts the player follows. This is a public feed, so drafts,
+ * hidden inventions and unlisted inventions stay out just as they do in search.
+ *
+ * Creator ids are passed to SQLite as one JSON array rather than expanded into one bind per
+ * id. A player can follow more accounts than D1 permits variables in one statement, while
+ * `json_each` keeps this a single indexed creator lookup regardless. Duplicate creator ids
+ * cannot duplicate inventions because membership is tested with `IN`.
+ */
+export async function getInventionsFromCreators(
+	db: D1Database,
+	creatorPlayerIds: number[],
+	skip: number,
+	take: number
+): Promise<SavedInvention[]> {
+	const limit = Math.max(take, 0)
+	const offset = Math.max(skip, 0)
+	if (creatorPlayerIds.length === 0 || limit === 0) return []
+
+	const creatorIds = JSON.stringify([...new Set(creatorPlayerIds)])
+	const { results } = await db
+		.prepare(
+			`SELECT data FROM invention
+			 WHERE creator_player_id IN (SELECT value FROM json_each(?1))
+			   AND ${VISIBLE_IN_FEEDS.join(' AND ')}
+			 ORDER BY json_extract(data, '$.CreatedAt') DESC, id DESC
+			 LIMIT ?2 OFFSET ?3`
+		)
+		.bind(creatorIds, limit, offset)
+		.all<InventionRow>()
+	return results.map((r) => JSON.parse(r.data) as SavedInvention)
+}
+
+/**
  * The player's "my inventions" shelf (`v2/mine`): everything they created, plus
  * everything they BOUGHT. Ownership of a bought invention lives in the
  * `inventory_invention` table the `econ` worker writes at purchase time — a creator is

--- a/apps/api/src/routes/avatar.ts
+++ b/apps/api/src/routes/avatar.ts
@@ -33,6 +33,7 @@ import {
 	getInventionById,
 	getInventionsByIds,
 	getInventionsByRoom,
+	getInventionsFromCreators,
 	getInventionTagFilters,
 	getInventionTags,
 	getInventionVersion,
@@ -1606,28 +1607,24 @@ export const avatarRoutes = new Hono<App>({ strict: false })
 	// Inventions by particular creators (`?id=207&id=…`) — what the client fills a creator's
 	// shelf, and the "from creators you follow" row, from.
 	//
-	// STUB: an empty list for now. It is the honest answer rather than a placeholder, since
-	// the client reads it as "this creator has published nothing" and renders an empty
-	// shelf, where a 404 would read as a row that failed to load. When it becomes real it is
-	// a filter on the invention table's creator column, the same feed shape as `toptoday`
-	// and `featured` above — `id` is repeatable, and `skip`/`take` page it.
 	.get(
 		'/api/inventions/v1/fromcreators',
 		describeRoute({
 			tags: ['Inventions'],
-			summary: 'Inventions by particular creators (stub)',
+			summary: 'Inventions by particular creators',
 			description:
 				'The published inventions of the accounts named by `id` (repeatable), newest first — ' +
-				'a creator’s shelf, and the "from creators you follow" row. STUB: always an empty ' +
-				'array for now, which the client renders as "nothing published" rather than as a ' +
-				'failed load. `id`, `skip` and `take` are accepted and, for the moment, ignored.',
-			parameters: [
-				intQuery('id', 'Creator account id; repeatable. Accepted and ignored by the stub'),
-				...pageParams(100),
-			],
-			responses: { 200: json(InventionDto.array(), 'Empty — nothing is served here yet') },
+				'a creator’s shelf, and the "from creators you follow" row. Drafts, hidden inventions ' +
+				'and unlisted inventions are excluded. `skip` and `take` page the combined feed.',
+			parameters: [intQuery('id', 'Creator account id; repeatable'), ...pageParams(100)],
+			responses: { 200: json(InventionDto.array(), 'The visible inventions from those creators') },
 		}),
-		(c) => c.json([])
+		async (c) => {
+			const creatorIds = inventionIdQuery(c)
+			const skip = Number.parseInt(c.req.query('skip') ?? '0', 10) || 0
+			const take = Number.parseInt(c.req.query('take') ?? '100', 10) || 100
+			return c.json(await getInventionsFromCreators(c.env.DB, creatorIds, skip, take))
+		}
 	)
 
 	// Invention search/browse: published inventions matching `value` (matched against

--- a/apps/api/src/test/integration/api.test.ts
+++ b/apps/api/src/test/integration/api.test.ts
@@ -3594,21 +3594,52 @@ describe('public endpoints', () => {
 		).toBe(403)
 	})
 
-	test('GET /api/inventions/v1/fromcreators is an empty feed for now', async () => {
-		// A stub: the client renders an empty array as "this creator has published nothing",
-		// where a 404 would read as a row that failed to load.
+	test('GET /api/inventions/v1/fromcreators serves a paginated public creator feed', async () => {
+		const invention = (
+			id: number,
+			creatorId: number,
+			createdAt: string,
+			overrides: Partial<SavedInvention> = {}
+		): SavedInvention =>
+			({
+				InventionId: id,
+				ReplicationId: crypto.randomUUID(),
+				CreatorPlayerId: creatorId,
+				Name: `Creator invention ${id}`,
+				Description: '',
+				ImageName: '',
+				CurrentVersionNumber: 1,
+				CurrentVersion: { InventionId: id, VersionNumber: 1, BlobName: '' },
+				IsPublished: true,
+				HideFromPlayer: false,
+				Accessibility: 1,
+				CreatedAt: createdAt,
+				...overrides,
+			}) as unknown as SavedInvention
+
+		for (const item of [
+			invention(50_101, 91_001, '2026-09-01T00:00:00Z'),
+			invention(50_102, 91_002, '2026-09-03T00:00:00Z'),
+			invention(50_103, 91_001, '2026-09-02T00:00:00Z'),
+			invention(50_104, 91_003, '2026-09-04T00:00:00Z'),
+			invention(50_105, 91_001, '2026-09-05T00:00:00Z', { IsPublished: false }),
+			invention(50_106, 91_001, '2026-09-06T00:00:00Z', { HideFromPlayer: true }),
+			invention(50_107, 91_001, '2026-09-07T00:00:00Z', { Accessibility: 2 }),
+		]) {
+			await env.DB.prepare('INSERT INTO invention (data) VALUES (?1)')
+				.bind(JSON.stringify(item))
+				.run()
+		}
+
 		const res = await exports.default.fetch(
-			`${ORIGIN}/api/inventions/v1/fromcreators?id=207&skip=0&take=100`
+			`${ORIGIN}/api/inventions/v1/fromcreators?id=91001&id=91002&id=91001&skip=1&take=2`
 		)
 		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual([])
+		expect(((await res.json()) as SavedInvention[]).map((i) => i.InventionId)).toEqual([
+			50_103, 50_101,
+		])
 
-		// The params are accepted and ignored, including a repeated `id` and none at all.
-		expect(
-			await (
-				await exports.default.fetch(`${ORIGIN}/api/inventions/v1/fromcreators?id=1&id=2`)
-			).json()
-		).toEqual([])
+		// Other creators and non-public inventions stay out; no creator ids means no feed.
 		expect(
 			await (await exports.default.fetch(`${ORIGIN}/api/inventions/v1/fromcreators`)).json()
 		).toEqual([])


### PR DESCRIPTION
## Summary
- replace the from-creators empty stub with a real invention feed
- support repeated creator account IDs
- return published, visible and listed inventions only
- sort the combined feed newest-first
- apply skip/take pagination in SQL
- deduplicate creator IDs without hitting D1's bind-variable ceiling
- add integration coverage for filtering, ordering, pagination and empty input

## Verification
- Type-check passed
- Lint passed
- API integration tests: 294 passed