### PR TITLE
[api] clean up failed custom avatar uploads

### DIFF
--- a/apps/api/src/custom-avatar-items-db.ts
+++ b/apps/api/src/custom-avatar-items-db.ts
@@ -154,6 +154,44 @@ export async function createCustomAvatarItem(
 	return toDto(row)
 }
 
+export interface CustomAvatarItemAsset {
+	bytes: ArrayBuffer
+	contentType: string
+}
+
+/**
+ * Store both assets and their metadata row as one failure-safe create operation.
+ *
+ * R2 and D1 cannot share a transaction, so a failure after either object write is
+ * compensated by deleting both fresh keys. Writes are deliberately sequential: with
+ * `Promise.all`, one rejected put can race cleanup while the other put is still completing
+ * and recreate an orphan after it was deleted. R2 deletes are idempotent, and both are
+ * attempted with `allSettled` so one cleanup failure cannot prevent the other.
+ */
+export async function createCustomAvatarItemWithAssets(
+	db: D1Database,
+	bucket: R2Bucket,
+	input: CreateCustomAvatarItemInput,
+	thumbnail: CustomAvatarItemAsset,
+	design: CustomAvatarItemAsset
+): Promise<CustomAvatarItem> {
+	try {
+		await bucket.put(input.thumbnailImageFilename, thumbnail.bytes, {
+			httpMetadata: { contentType: thumbnail.contentType },
+		})
+		await bucket.put(input.designFilename, design.bytes, {
+			httpMetadata: { contentType: design.contentType },
+		})
+		return await createCustomAvatarItem(db, input)
+	} catch (error) {
+		await Promise.allSettled([
+			bucket.delete(input.thumbnailImageFilename),
+			bucket.delete(input.designFilename),
+		])
+		throw error
+	}
+}
+
 /**
  * The `ItemType` that names a custom avatar item in a UGC-purchasable reference
  * (`POST /api/ugcPurchasables/v1/items/bulk`'s `Ids[].itemType`).

--- a/apps/api/src/routes/avatar.ts
+++ b/apps/api/src/routes/avatar.ts
@@ -15,7 +15,7 @@ import {
 } from '@repo/domain'
 
 import {
-	createCustomAvatarItem,
+	createCustomAvatarItemWithAssets,
 	deleteCustomAvatarItem,
 	getCustomAvatarItem,
 	getCustomAvatarItems,
@@ -518,27 +518,30 @@ export const avatarRoutes = new Hono<App>({ strict: false })
 			const prefix = `avatar-item/${new Date().toISOString().slice(0, 10)}/${customAvatarItemId}`
 			const thumbnailImageFilename = `${prefix}-thumb.png`
 			const designFilename = `${prefix}-design.png`
-			await Promise.all([
-				c.env.IMAGES.put(thumbnailImageFilename, await body.thumbnailImage.arrayBuffer(), {
-					httpMetadata: { contentType: body.thumbnailImage.type || 'image/png' },
-				}),
-				c.env.IMAGES.put(designFilename, await body.design.arrayBuffer(), {
-					httpMetadata: { contentType: body.design.type || 'image/png' },
-				}),
-			])
-
-			const item = await createCustomAvatarItem(c.env.DB, {
-				customAvatarItemId,
-				creatorAccountId: id,
-				name: meta.Name,
-				description: typeof meta.Description === 'string' ? meta.Description : '',
-				price: typeof meta.Price === 'number' ? meta.Price : 0,
-				baseAvatarItemId: meta.BaseAvatarItemId,
-				baseAvatarItemColor: meta.BaseAvatarItemColor,
-				accessibility: typeof meta.Accessibility === 'number' ? meta.Accessibility : 0,
-				designFilename,
-				thumbnailImageFilename,
-			})
+			const item = await createCustomAvatarItemWithAssets(
+				c.env.DB,
+				c.env.IMAGES,
+				{
+					customAvatarItemId,
+					creatorAccountId: id,
+					name: meta.Name,
+					description: typeof meta.Description === 'string' ? meta.Description : '',
+					price: typeof meta.Price === 'number' ? meta.Price : 0,
+					baseAvatarItemId: meta.BaseAvatarItemId,
+					baseAvatarItemColor: meta.BaseAvatarItemColor,
+					accessibility: typeof meta.Accessibility === 'number' ? meta.Accessibility : 0,
+					designFilename,
+					thumbnailImageFilename,
+				},
+				{
+					bytes: await body.thumbnailImage.arrayBuffer(),
+					contentType: body.thumbnailImage.type || 'image/png',
+				},
+				{
+					bytes: await body.design.arrayBuffer(),
+					contentType: body.design.type || 'image/png',
+				}
+			)
 			return c.json({ Value: item, Success: true, Error: null, error_id: null })
 		}
 	)

--- a/apps/api/src/test/integration/api.test.ts
+++ b/apps/api/src/test/integration/api.test.ts
@@ -33,6 +33,7 @@ import { PLATFORM_SCHEMA_DDL } from '../../../../auth/src/platform-db'
 import { banEvasionMatch, resolveBan } from '../../bans-db'
 import {
 	createCustomAvatarItem,
+	createCustomAvatarItemWithAssets,
 	SCHEMA_DDL as CUSTOM_AVATAR_ITEM_SCHEMA_DDL,
 } from '../../custom-avatar-items-db'
 import {
@@ -3934,6 +3935,82 @@ describe('custom avatar items', () => {
 			.bind(body.Value.CustomAvatarItemId)
 			.first()
 		expect(row).toEqual({ name: 'custom shirt 1', creator_account_id: 205 })
+	})
+
+	test('custom avatar creation cleans up both R2 keys after every partial failure', async () => {
+		const input = (id: string) => ({
+			customAvatarItemId: id,
+			creatorAccountId: 205,
+			name: 'failure-safe item',
+			description: '',
+			price: 0,
+			baseAvatarItemId: 1,
+			baseAvatarItemColor: '#fff',
+			accessibility: 0,
+			designFilename: `avatar-item/test/${id}-design.png`,
+			thumbnailImageFilename: `avatar-item/test/${id}-thumb.png`,
+		})
+		const asset = { bytes: new Uint8Array([1]).buffer, contentType: 'image/png' }
+
+		const fakeBucket = (failPutAt?: number, failDeleteAt?: number) => {
+			const objects = new Set<string>()
+			const deleted: string[] = []
+			let puts = 0
+			let deletes = 0
+			const bucket = {
+				put: async (key: string) => {
+					puts += 1
+					if (puts === failPutAt) throw new Error(`put ${puts} failed`)
+					objects.add(key)
+					return {} as R2Object
+				},
+				delete: async (key: string) => {
+					deletes += 1
+					deleted.push(key)
+					if (deletes === failDeleteAt) throw new Error(`delete ${deletes} failed`)
+					objects.delete(key)
+				},
+			} as unknown as R2Bucket
+			return { bucket, objects, deleted }
+		}
+
+		const firstId = crypto.randomUUID()
+		const first = fakeBucket(1)
+		await expect(
+			createCustomAvatarItemWithAssets(env.DB, first.bucket, input(firstId), asset, asset)
+		).rejects.toThrow('put 1 failed')
+		expect(first.objects.size).toBe(0)
+		expect(first.deleted).toEqual([
+			input(firstId).thumbnailImageFilename,
+			input(firstId).designFilename,
+		])
+
+		// Even if one idempotent delete fails, the other key is still cleaned and the original
+		// upload error remains the one the caller receives.
+		const secondId = crypto.randomUUID()
+		const second = fakeBucket(2, 1)
+		await expect(
+			createCustomAvatarItemWithAssets(env.DB, second.bucket, input(secondId), asset, asset)
+		).rejects.toThrow('put 2 failed')
+		expect(second.deleted).toEqual([
+			input(secondId).thumbnailImageFilename,
+			input(secondId).designFilename,
+		])
+		expect(second.objects.has(input(secondId).designFilename)).toBe(false)
+
+		// A duplicate id forces the D1 insert to fail after both writes. Both fresh objects
+		// must be removed rather than becoming unreferenced bucket data.
+		const duplicateId = crypto.randomUUID()
+		await createCustomAvatarItem(env.DB, input(duplicateId))
+		const database = fakeBucket()
+		await expect(
+			createCustomAvatarItemWithAssets(env.DB, database.bucket, input(duplicateId), asset, asset)
+		).rejects.toThrow()
+		expect(database.objects.size).toBe(0)
+		expect(database.deleted).toEqual([
+			input(duplicateId).thumbnailImageFilename,
+			input(duplicateId).designFilename,
+		])
 	})
 
 	test('PUT edits the creator’s item, leaving nulled fields alone', async () => {


### PR DESCRIPTION
## Summary
- make custom-avatar asset and metadata creation failure-safe
- write the two R2 objects sequentially to prevent put/cleanup races
- remove both generated keys when either upload fails
- remove uploaded assets when the D1 metadata insert fails
- attempt both idempotent deletions even if one cleanup operation fails
- preserve the original upload or database error
- add deterministic coverage for first-write, second-write and database failures

## Verification
- Type-check passed
- Lint passed
- API integration tests: 295 passed