### PR TITLE
[econ] serve owned custom avatar items

### DIFF
--- a/apps/api/src/custom-avatar-items-db.ts
+++ b/apps/api/src/custom-avatar-items-db.ts
@@ -350,24 +350,40 @@ export async function searchCustomAvatarItems(
  * What an account has authored (`GET /api/customAvatarItems/v2/fromCreator/:id`), newest
  * first, with the total for the client's paginated envelope. `includeUnpublished` is for
  * the creator looking at their own shelf: it adds the `Accessibility` 0 items everyone
- * else is not shown. Paging is not applied yet (the client sends none), so `TotalResults`
- * always equals the list length.
+ * else is not shown. When a page is requested, `Results` is sliced in SQL while
+ * `TotalResults` remains the complete matching count. Omitting `page` preserves the
+ * unpaged creator-profile response.
  */
 export async function listCustomAvatarItemsByCreator(
 	db: D1Database,
 	creatorAccountId: number,
-	includeUnpublished = false
+	includeUnpublished = false,
+	page?: { skip: number; take: number }
 ): Promise<{ Results: CustomAvatarItem[]; TotalResults: number }> {
-	const { results } = await db
-		.prepare(
-			`SELECT * FROM custom_avatar_item
-			 WHERE creator_account_id = ?1 AND (accessibility != 0 OR ?2)
-			 ORDER BY created_at DESC, custom_avatar_item_id`
-		)
-		.bind(creatorAccountId, includeUnpublished ? 1 : 0)
-		.all<Row>()
-	const items = results.map(toDto)
-	return { Results: items, TotalResults: items.length }
+	const where = 'creator_account_id = ?1 AND (accessibility != 0 OR ?2)'
+	const binds = [creatorAccountId, includeUnpublished ? 1 : 0]
+	const paging = page
+		? {
+				skip: Math.max(page.skip, 0),
+				take: Math.min(Math.max(page.take, 0), 200),
+			}
+		: null
+
+	const [rows, count] = await Promise.all([
+		db
+			.prepare(
+				`SELECT * FROM custom_avatar_item WHERE ${where}
+				 ORDER BY created_at DESC, custom_avatar_item_id
+				 ${paging === null ? '' : 'LIMIT ?3 OFFSET ?4'}`
+			)
+			.bind(...binds, ...(paging === null ? [] : [paging.take, paging.skip]))
+			.all<Row>(),
+		db
+			.prepare(`SELECT COUNT(*) AS total FROM custom_avatar_item WHERE ${where}`)
+			.bind(...binds)
+			.first<{ total: number }>(),
+	])
+	return { Results: rows.results.map(toDto), TotalResults: count?.total ?? 0 }
 }
 
 /** The editable fields of `PUT /api/customAvatarItems/v1/:id`; null/undefined = leave alone. */

--- a/apps/econ/README.md
+++ b/apps/econ/README.md
@@ -19,7 +19,7 @@ missing/invalid). `~` = optional auth: served to anyone, personalised for a vali
 | GET      | `/api/avatar/v1/defaultunlocked`                     |      | Default-unlocked avatar items (static)  |
 | GET      | `/api/avatar/v1/defaultbaseavataritems`              |      | Default base avatar items (stub `[]`)   |
 | GET      | `/api/avatar/v4/items`                               | ✓    | Owned items + the default catalog       |
-| GET      | `/econ/customAvatarItems/v1/owned`                   | ✓    | Owned custom avatar items (stub)        |
+| GET      | `/econ/customAvatarItems/v1/owned`                   | ✓    | Owned custom avatar items               |
 | GET      | `/api/objectives/v1/myprogress`                      |      | Objectives progress (static)            |
 | GET/POST | `/api/objectives/v1/cleargroup`                      |      | Clear an objectives group (no-op `[]`)  |
 | GET      | `/api/avatar/v2`                                     | ✓    | The player's own avatar                 |

--- a/apps/econ/src/econ.app.ts
+++ b/apps/econ/src/econ.app.ts
@@ -21,6 +21,7 @@ import { validateAndGetAccountId, validateAndGetPlus, validateAndGetVersion } fr
 
 import {
 	getCustomAvatarItems,
+	listCustomAvatarItemsByCreator,
 	toUgcPurchasable,
 	UGC_ITEM_TYPE_CUSTOM_AVATAR_ITEM,
 } from '../../api/src/custom-avatar-items-db'
@@ -101,6 +102,7 @@ import {
 	GameRewardRequest,
 	InfluencerIdsResponse,
 	InfluencerTierResponse,
+	intQuery,
 	ItemPurchaseInfoList,
 	ItemPurchaseInfosRequest,
 	json,
@@ -2375,29 +2377,38 @@ const app = new Hono<App>({ strict: false })
 		}
 	)
 
-	// The player's owned custom avatar items. [Authorize]; paginated. Empty stub for
-	// now (no DB binding). The client downloads these when custom-item creation is
-	// allowed; a 404 here surfaces as "Failed to download unlocked avatar items".
+	// The player's owned custom avatar items. These are authored items in the shared
+	// api-owned table, including the caller's unpublished drafts. The client downloads
+	// these when custom-item creation is allowed; a 404 here surfaces as "Failed to
+	// download unlocked avatar items".
 	.get(
 		'/econ/customAvatarItems/v1/owned',
 		describeRoute({
 			tags: ['Avatar'],
 			summary: 'Owned custom avatar items',
 			description: [
-				'Paginated owned custom items. Empty stub for now. The client requests this when',
-				'custom-item creation is allowed; a 404 shows as “Failed to download unlocked',
-				'avatar items”.',
+				'Custom avatar items authored by the caller, including unpublished drafts, newest',
+				'first. The shared custom_avatar_item table is owned by the api worker; skip/take',
+				'page its rows here while TotalResults remains the complete authored count.',
 			].join(' '),
 			security: AUTHED,
+			parameters: [
+				intQuery('skip', 'How many owned items to skip (default 0)'),
+				intQuery('take', 'How many owned items to return (default 50, maximum 200)'),
+			],
 			responses: {
-				200: json(CustomAvatarItemsResponse, 'Paginated results (empty for now)'),
+				200: json(CustomAvatarItemsResponse, 'The caller’s paginated authored items'),
 				401: UNAUTHORIZED_RESPONSE,
 			},
 		}),
 		async (c) => {
 			const id = await authedId(c)
 			if (id === null) return unauthorized(c)
-			return c.json({ Results: [], TotalResults: 0 })
+			const skip = Number.parseInt(c.req.query('skip') ?? '0', 10) || 0
+			const take = Number.parseInt(c.req.query('take') ?? '50', 10) || 50
+			return c.json(
+				await listCustomAvatarItemsByCreator(c.env.DB, id, true, { skip, take })
+			)
 		}
 	)
 

--- a/apps/econ/src/openapi.ts
+++ b/apps/econ/src/openapi.ts
@@ -57,6 +57,11 @@ export const AUTHED = [{ bearerAuth: [] }]
  */
 export const OPTIONAL_AUTHED: OpenAPIV3_1.SecurityRequirementObject[] = [{}, { bearerAuth: [] }]
 
+/** An optional integer query parameter. */
+export function intQuery(name: string, description: string): OpenAPIV3_1.ParameterObject {
+	return { name, in: 'query', required: false, description, schema: { type: 'integer' } }
+}
+
 // ---- Loose shapes ----------------------------------------------------------
 // Several routes serve opaque static catalogs (avatar items, the weekly challenge) or
 // empty-list stubs. Modelling every catalog field adds noise without value, so these

--- a/apps/econ/src/test/integration/api.test.ts
+++ b/apps/econ/src/test/integration/api.test.ts
@@ -492,14 +492,63 @@ describe('econ endpoints', () => {
 		expect(res.status).toBe(404)
 	})
 
-	test('GET /econ/customAvatarItems/v1/owned 401s without a token, returns an empty paginated stub', async () => {
+	test('GET /econ/customAvatarItems/v1/owned returns only the caller’s paginated authored items', async () => {
 		const anon = await exports.default.fetch(`${ORIGIN}/econ/customAvatarItems/v1/owned`)
 		expect(anon.status).toBe(401)
-		const res = await exports.default.fetch(`${ORIGIN}/econ/customAvatarItems/v1/owned`, {
-			headers: await bearer(),
+
+		const customItem = (
+			creatorAccountId: number,
+			name: string,
+			accessibility: number,
+			createdAt: string
+		) =>
+			createCustomAvatarItem(
+				env.DB,
+				{
+					customAvatarItemId: crypto.randomUUID(),
+					creatorAccountId,
+					name,
+					description: '',
+					price: 0,
+					baseAvatarItemId: 1,
+					baseAvatarItemColor: '#fff',
+					accessibility,
+					designFilename: `${name}-design.png`,
+					thumbnailImageFilename: `${name}-thumb.png`,
+				},
+				new Date(createdAt)
+			)
+
+		await customItem(62_000, 'older public', 1, '2026-06-01T00:00:00Z')
+		await customItem(62_000, 'middle draft', 0, '2026-06-02T00:00:00Z')
+		await customItem(62_000, 'newest public', 1, '2026-06-03T00:00:00Z')
+		await customItem(62_001, 'someone else', 1, '2026-06-04T00:00:00Z')
+
+		const first = await exports.default.fetch(
+			`${ORIGIN}/econ/customAvatarItems/v1/owned?skip=0&take=2`,
+			{ headers: await bearer('62000') }
+		)
+		expect(first.status).toBe(200)
+		const firstPage = (await first.json()) as {
+			Results: Array<{ CreatorAccountId: number; Name: string; Accessibility: number }>
+			TotalResults: number
+		}
+		expect(firstPage.TotalResults).toBe(3)
+		expect(firstPage.Results.map((item) => item.Name)).toEqual([
+			'newest public',
+			'middle draft',
+		])
+		expect(firstPage.Results.every((item) => item.CreatorAccountId === 62_000)).toBe(true)
+		expect(firstPage.Results[1]?.Accessibility).toBe(0)
+
+		const second = await exports.default.fetch(
+			`${ORIGIN}/econ/customAvatarItems/v1/owned?skip=2&take=2`,
+			{ headers: await bearer('62000') }
+		)
+		expect(await second.json()).toMatchObject({
+			Results: [{ Name: 'older public', CreatorAccountId: 62_000 }],
+			TotalResults: 3,
 		})
-		expect(res.status).toBe(200)
-		expect(await res.json()).toEqual({ Results: [], TotalResults: 0 })
 	})
 
 	test('GET /api/objectives/v1/myprogress returns the default progress (no auth)', async () => {


### PR DESCRIPTION
## Summary
- replace the owned custom-avatar-items stub with shared-D1 results
- scope results to the authenticated creator
- include the creator's unpublished drafts
- return items newest-first with stable ordering
- implement skip/take pagination with a maximum page size of 200
- keep TotalResults as the complete unpaged count
- preserve the existing unpaged API creator-shelf behavior
- update OpenAPI metadata and the econ route table

## Verification
- Econ type-check passed
- Econ lint passed
- Econ integration tests: 150 passed
- API type-check passed
- API lint passed
- API integration tests: 294 passed