### PR TITLE
[api] suppress duplicate player-report retries

### DIFF
--- a/apps/api/src/reports-db.ts
+++ b/apps/api/src/reports-db.ts
@@ -159,6 +159,51 @@ export async function createReport(db: D1Database, input: NewReport): Promise<Re
 	return row!
 }
 
+/**
+ * Record an ordinary player report unless the same caller recently submitted the same
+ * incident. Category, details and room context distinguish legitimate later incidents;
+ * heights are measurements rather than incident identity and are intentionally ignored.
+ * The single INSERT ... SELECT also makes concurrent client retries safe.
+ */
+export async function createPlayerReportOnce(
+	db: D1Database,
+	input: NewReport,
+	options: { now?: Date; replayWindowMs?: number } = {}
+): Promise<ReportRow | null> {
+	const now = options.now ?? new Date()
+	const cutoff = new Date(now.getTime() - (options.replayWindowMs ?? 5 * 60_000)).toISOString()
+	return db
+		.prepare(
+			`INSERT INTO report (
+				reporter_player_id, reported_player_id, report_category, details,
+				height_reporter, height_reported, room_id, room_instance_type, created_at
+			 )
+			 SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9
+			 WHERE NOT EXISTS (
+				SELECT 1 FROM report
+				 WHERE reporter_player_id = ?1 AND reported_player_id = ?2
+					AND report_category = ?3 AND details IS ?4
+					AND room_id IS ?7 AND room_instance_type IS ?8
+					AND event_id IS NULL AND invention_id IS NULL
+					AND custom_avatar_item_id IS NULL AND created_at >= ?10
+			 )
+			 RETURNING *`
+		)
+		.bind(
+			input.reporterPlayerId,
+			input.reportedPlayerId,
+			input.reportCategory ?? 0,
+			input.details ?? null,
+			input.heightReporter ?? null,
+			input.heightReported ?? null,
+			input.roomId ?? null,
+			input.roomInstanceType ?? null,
+			now.toISOString(),
+			cutoff
+		)
+		.first<ReportRow>()
+}
+
 /** Every report filed against a player, newest first. Backs a future moderation view. */
 export async function getReportsAgainst(db: D1Database, playerId: number): Promise<ReportRow[]> {
 	const { results } = await db

--- a/apps/api/src/routes/moderation.ts
+++ b/apps/api/src/routes/moderation.ts
@@ -35,7 +35,7 @@ import {
 	VoteToKickReason,
 	VoteToKickRequest,
 } from '../openapi'
-import { createReport, getActiveBan } from '../reports-db'
+import { createPlayerReportOnce, getActiveBan } from '../reports-db'
 import { createWarning } from '../warnings-db'
 
 import type { Context } from 'hono'
@@ -434,7 +434,8 @@ export const moderationRoutes = new Hono<App>({ strict: false })
 			tags: ['Moderation'],
 			summary: 'Submit a player report',
 			description:
-				'Records a player report in the `report` table; nothing dedupes the rows. A report ' +
+				'Records a player report in the `report` table. Identical retries by the same ' +
+				'caller are accepted but stored only once within a five-minute window. A report ' +
 				'is filed unbanned — a moderator converts one into an account-wide ban by setting ' +
 				'`banned` on the row, which is what matchmaking refuses on and what ' +
 				'`moderationBlockDetails` describes to the banned player.\n\n' +
@@ -467,7 +468,7 @@ export const moderationRoutes = new Hono<App>({ strict: false })
 			// 0 / -1 are the client's "no room" values — store null rather than a bogus id.
 			const roomId = asInt(formField(body, c, 'RoomId'))
 
-			await createReport(c.env.DB, {
+			await createPlayerReportOnce(c.env.DB, {
 				reporterPlayerId: reporterId,
 				reportedPlayerId,
 				reportCategory: asInt(formField(body, c, 'ReportCategory')) ?? 0,

--- a/apps/api/src/test/integration/api.test.ts
+++ b/apps/api/src/test/integration/api.test.ts
@@ -4550,14 +4550,34 @@ describe('player reports', () => {
 		})
 	})
 
-	// Append-only: a second report against the same player is a second row.
-	test('POST /api/PlayerReporting/v3/create appends rather than dedupes', async () => {
-		await submit({ PlayerIdReported: '207', Details: 'first' }, await bearer())
-		await submit({ PlayerIdReported: '207', Details: 'second' }, await bearer())
+	test('POST /api/PlayerReporting/v3/create suppresses a recent identical replay', async () => {
+		const fields = { PlayerIdReported: '207', ReportCategory: '100', Details: 'same incident' }
+		const first = await submit(fields, await bearer())
+		const replay = await submit(fields, await bearer())
+		expect(first.status).toBe(200)
+		expect(await first.json()).toEqual({ success: true, error: '' })
+		expect(replay.status).toBe(200)
+		expect(await replay.json()).toEqual({ success: true, error: '' })
 		const rows = await getReportsAgainst(env.DB, 207)
-		expect(rows).toHaveLength(2)
-		// Newest first.
-		expect(rows.map((r) => r.details)).toEqual(['second', 'first'])
+		expect(rows).toHaveLength(1)
+	})
+
+	test('POST /api/PlayerReporting/v3/create keeps distinct incidents and targets', async () => {
+		await submit({ PlayerIdReported: '208', Details: 'first incident' }, await bearer())
+		await submit({ PlayerIdReported: '208', Details: 'second incident' }, await bearer())
+		await submit({ PlayerIdReported: '209', Details: 'first incident' }, await bearer())
+		expect(await getReportsAgainst(env.DB, 208)).toHaveLength(2)
+		expect(await getReportsAgainst(env.DB, 209)).toHaveLength(1)
+	})
+
+	test('POST /api/PlayerReporting/v3/create accepts the incident after the replay window', async () => {
+		const fields = { PlayerIdReported: '215', Details: 'recurring incident' }
+		await submit(fields, await bearer())
+		await env.DB.prepare(
+			"UPDATE report SET created_at = '2020-01-01T00:00:00.000Z' WHERE reported_player_id = 215"
+		).run()
+		await submit(fields, await bearer())
+		expect(await getReportsAgainst(env.DB, 215)).toHaveLength(2)
 	})
 
 	test('POST /api/PlayerReporting/v3/create 401s without a bearer token', async () => {
@@ -6740,9 +6760,7 @@ describe('player events', () => {
 			upcoming.PlayerEventId,
 		])
 		// The same base projection the POST serves: one path, one shape.
-		expect(events.find((e) => e.PlayerEventId === upcoming.PlayerEventId)).toEqual(
-			asBase(upcoming)
-		)
+		expect(events.find((e) => e.PlayerEventId === upcoming.PlayerEventId)).toEqual(asBase(upcoming))
 
 		// No ids is an empty list, not every event.
 		expect(await (await get('/api/playerevents/v1/bulk')).json()).toEqual([])


### PR DESCRIPTION
## Summary
- suppress identical player-report retries for five minutes
- use an atomic D1 insert to prevent races
- distinguish reports by target, category, details and room context
- preserve separate incidents and different targets
- preserve the existing success response for accepted retries
- exclude event, invention and custom-avatar reports

## Verification
- API type-check passed
- API lint passed
- API integration tests: 296 passed