### PR TITLE
[playersettings] ignore invalid JSON entries

### DIFF
--- a/apps/playersettings/src/playersettings.app.ts
+++ b/apps/playersettings/src/playersettings.app.ts
@@ -57,6 +57,7 @@ async function parseSettings(c: Context<App>): Promise<Array<{ key: string; valu
 		const list = Array.isArray(body) ? body : body == null ? [] : [body]
 		return list
 			.map((o) => {
+				if (typeof o !== 'object' || o === null) return { key: '', value: '' }
 				const rec = o as Record<string, unknown>
 				const key = rec.key ?? rec.Key
 				const value = rec.value ?? rec.Value
@@ -96,6 +97,7 @@ async function parseDeleteKeys(c: Context<App>): Promise<string[]> {
 		return list
 			.map((o) => {
 				if (typeof o === 'string') return o
+				if (typeof o !== 'object' || o === null) return ''
 				const rec = o as Record<string, unknown>
 				const key = rec.key ?? rec.Key
 				return typeof key === 'string' ? key : ''

--- a/apps/playersettings/src/test/integration/api.test.ts
+++ b/apps/playersettings/src/test/integration/api.test.ts
@@ -145,6 +145,21 @@ describe('playersettings endpoints', () => {
 		expect(res.status).toBe(200)
 	})
 
+	it('PUT /playersettings ignores null and primitive JSON array entries', async () => {
+		const res = await SELF.fetch(`${ORIGIN}/playersettings`, {
+			method: 'PUT',
+			headers: { 'Content-Type': 'application/json', ...(await bearer('10')) },
+			body: JSON.stringify([null, 12, false, { Key: 'PlayerSessionCount', Value: 4 }]),
+		})
+		expect(res.status).toBe(200)
+
+		const stored = await env.RECFLARE_PLAYER_SETTINGS.get<Record<string, string>>(
+			'player:10',
+			'json'
+		)
+		expect(stored).toEqual({ PlayerSessionCount: '4' })
+	})
+
 	it('DELETE /playersettings 401s without a token', async () => {
 		const res = await SELF.fetch(
 			`${ORIGIN}/playersettings`,
@@ -217,6 +232,26 @@ describe('playersettings endpoints', () => {
 			'json'
 		)
 		expect(stored).toEqual({ A: '1' })
+	})
+
+	it('DELETE /playersettings ignores null and primitive JSON array entries', async () => {
+		await env.RECFLARE_PLAYER_SETTINGS.put(
+			'player:23',
+			JSON.stringify({ Keep: 'yes', Remove: 'me' })
+		)
+
+		const res = await SELF.fetch(`${ORIGIN}/playersettings`, {
+			method: 'DELETE',
+			headers: { 'Content-Type': 'application/json', ...(await bearer('23')) },
+			body: JSON.stringify([null, 12, false, { Key: 'Remove' }]),
+		})
+		expect(res.status).toBe(200)
+
+		const stored = await env.RECFLARE_PLAYER_SETTINGS.get<Record<string, string>>(
+			'player:23',
+			'json'
+		)
+		expect(stored).toEqual({ Keep: 'yes' })
 	})
 
 	it('GET /openapi.json documents every route', async () => {


### PR DESCRIPTION
## Summary
- prevent null JSON entries from crashing PUT and DELETE
- ignore unsupported primitive entries
- continue processing valid entries in mixed arrays
- preserve documented lenient no-op behavior
- add regression coverage for mixed valid and invalid input

## Verification
- Type-check passed
- Type-aware lint passed
- Player-settings integration tests: 15 passed