### PR TITLE
[chat] reject partial MessageCount values

### DIFF
--- a/apps/chat/src/chat.app.ts
+++ b/apps/chat/src/chat.app.ts
@@ -84,8 +84,11 @@ const DEFAULT_THREAD_MESSAGE_COUNT = 50
 function messageCount(c: Context<App>, fallback = DEFAULT_MESSAGE_COUNT): number {
 	// The GET routes spell it `MessageCount` in the query; the POST forms spell it
 	// `messageCount` in the body. Accept either, wherever it turns up.
-	const raw = Number.parseInt(c.req.query('MessageCount') ?? c.req.query('messageCount') ?? '', 10)
-	if (Number.isNaN(raw) || raw <= 0) return fallback
+	const value = (c.req.query('MessageCount') ?? c.req.query('messageCount') ?? '').trim()
+	if (!/^\d+$/.test(value)) return fallback
+
+	const raw = Number(value)
+	if (!Number.isSafeInteger(raw) || raw <= 0) return fallback
 	return Math.min(raw, MAX_MESSAGE_COUNT)
 }
 


### PR DESCRIPTION
## Summary
Reject partially numeric `MessageCount` values such as `16junk` instead of silently treating them as 16.

- require an all-digit value
- require a positive safe integer
- preserve the existing fallback and 100-message cap

This keeps malformed hand-written requests from being accepted differently from their documented integer shape.