### PR TITLE
[storage] require exact upload FileType values

### DIFF
--- a/apps/storage/src/storage.app.ts
+++ b/apps/storage/src/storage.app.ts
@@ -48,9 +48,18 @@ const UPLOAD_SUBFOLDER: Record<number, string> = {
 	6: 'roommetadata',
 }
 
+/** Parse a posted FileType only when the complete value is a decimal integer. */
+function parseFileType(fileType: string): number | undefined {
+	const value = fileType.trim()
+	if (!/^\d+$/.test(value)) return undefined
+	const parsed = Number(value)
+	return Number.isSafeInteger(parsed) ? parsed : undefined
+}
+
 /** Resolve the storage subfolder for a posted FileType, or `undefined` when unknown. */
 function subfolderForFileType(fileType: string): string | undefined {
-	return UPLOAD_SUBFOLDER[Number.parseInt(fileType, 10)]
+	const parsed = parseFileType(fileType)
+	return parsed === undefined ? undefined : UPLOAD_SUBFOLDER[parsed]
 }
 
 /**
@@ -77,7 +86,8 @@ function maxUploadBytes(value: unknown): number {
 }
 
 function extensionForFileType(fileType: string): string {
-	return UPLOAD_EXTENSION[Number.parseInt(fileType, 10)] ?? ''
+	const parsed = parseFileType(fileType)
+	return parsed === undefined ? '' : (UPLOAD_EXTENSION[parsed] ?? '')
 }
 
 /** Read a text form field by any of its accepted names, matched case-insensitively. */


### PR DESCRIPTION
## Summary
Require the complete posted `FileType` value to match a decimal enum value.

`parseInt()` previously accepted malformed values like `5oops` as invention uploads. Both destination and extension selection now share the same strict safe-integer parser, while valid FileType values keep identical behavior.