### PR TITLE
[clubs] strictly parse path club ids

### DIFF
--- a/apps/clubs/src/clubs.app.ts
+++ b/apps/clubs/src/clubs.app.ts
@@ -464,7 +464,9 @@ const app = new Hono<App>()
 			responses: { 200: json(ClubAnnouncementsEnvelope, 'The club’s noticeboard') },
 		}),
 		async (c) => {
-			const clubId = Number.parseInt(c.req.param('clubId'), 10)
+			const rawClubId = c.req.param('clubId').trim()
+			const clubId = /^\d+$/.test(rawClubId) ? Number(rawClubId) : Number.NaN
+			if (!Number.isSafeInteger(clubId) || clubId <= 0) return c.json([])
 			const announcements = await getClubAnnouncements(c.env.DB, clubId)
 			return c.json({
 				error: '',


### PR DESCRIPTION
Require club path IDs to be complete positive safe integers before querying announcements.