### PR TITLE
[lists] strictly parse creator account ids

### DIFF
--- a/apps/lists/src/lists.app.ts
+++ b/apps/lists/src/lists.app.ts
@@ -447,9 +447,10 @@ async function ownedList(
 	type: string | undefined,
 	name: string | undefined
 ): Promise<CuratedList | undefined> {
-	const accountId = Number.parseInt(creatorAccountId ?? '', 10)
+	const rawAccountId = (creatorAccountId ?? '').trim()
+	const accountId = /^\d+$/.test(rawAccountId) ? Number(rawAccountId) : Number.NaN
 	const listType = Number.parseInt(type ?? '', 10)
-	if (!Number.isInteger(accountId) || !Number.isInteger(listType) || !name) return undefined
+	if (!Number.isSafeInteger(accountId) || !Number.isInteger(listType) || !name) return undefined
 
 	return getPlayerList(c.env.DB, accountId, listType, name)
 }


### PR DESCRIPTION
Require creatorAccountId to be a complete safe integer when resolving curated lists.