### PR TITLE
[lists] strictly parse curated list types

### DIFF
--- a/apps/lists/src/lists.app.ts
+++ b/apps/lists/src/lists.app.ts
@@ -448,8 +448,9 @@ async function ownedList(
 	name: string | undefined
 ): Promise<CuratedList | undefined> {
 	const accountId = Number.parseInt(creatorAccountId ?? '', 10)
-	const listType = Number.parseInt(type ?? '', 10)
-	if (!Number.isInteger(accountId) || !Number.isInteger(listType) || !name) return undefined
+	const rawListType = (type ?? '').trim()
+	const listType = /^-?\d+$/.test(rawListType) ? Number(rawListType) : Number.NaN
+	if (!Number.isInteger(accountId) || !Number.isSafeInteger(listType) || !name) return undefined
 
 	return getPlayerList(c.env.DB, accountId, listType, name)
 }


### PR DESCRIPTION
Require curated-list type values to be complete safe integers instead of accepting partially numeric values.