### PR TITLE
[auth] make deviceClass regression assertion structural

### DIFF
--- a/apps/auth/src/test/integration/api.test.ts
+++ b/apps/auth/src/test/integration/api.test.ts
@@ -860,8 +860,9 @@ describe('auth worker routes', () => {
 		const row = await env.DB.prepare('SELECT data FROM account WHERE account_id = ?1')
 			.bind(77)
 			.first<{ data: string }>()
-		expect(row!.data).toContain('"deviceClass":2')
-		expect(row!.data).not.toContain('2.0')
+		const stored = JSON.parse(row!.data) as { deviceClass?: unknown }
+		expect(stored.deviceClass).toBe(2)
+		expect(Number.isInteger(stored.deviceClass)).toBe(true)
 	})
 
 	test('POST /connect/token refreshes the stored device on a credential login', async () => {


### PR DESCRIPTION
## Summary
Make the cached-login `deviceClass` regression test inspect the parsed JSON field instead of searching the entire serialized row for the substring `2.0`.

The old assertion could fail when unrelated fields such as timestamps happened to contain `2.0`, even while `deviceClass` was correctly stored as the integer `2`.