### PR TITLE
[rooms] strictly parse single room lookup ids

### DIFF
--- a/apps/rooms/src/rooms.app.ts
+++ b/apps/rooms/src/rooms.app.ts
@@ -157,8 +157,10 @@ import type { App } from './context'
 function firstId(idParam: string): number | undefined {
 	return idParam
 		.split(',')
-		.map((s) => Number.parseInt(s.trim(), 10))
-		.find((n) => !Number.isNaN(n))
+		.map((s) => s.trim())
+		.filter((s) => /^\d+$/.test(s))
+		.map(Number)
+		.find((n) => Number.isSafeInteger(n) && n > 0)
 }
 
 /** Parse all valid integer ids from a comma-separated `id` query param. */


### PR DESCRIPTION
## Summary
Require comma-separated room lookup IDs to be complete safe integers before choosing the first valid ID. This stops values like `12junk` from resolving room 12.