### PR TITLE
[rooms] strictly parse base-room pagination

### DIFF
--- a/apps/rooms/src/rooms.app.ts
+++ b/apps/rooms/src/rooms.app.ts
@@ -949,8 +949,12 @@ const app = new Hono<App>()
 			responses: { 200: json(RoomDto.array(), 'The template rooms') },
 		}),
 		async (c) => {
-			const skip = Number.parseInt(c.req.query('skip') ?? '0', 10) || 0
-			const take = Number.parseInt(c.req.query('take') ?? '100', 10) || 100
+			const rawSkip = (c.req.query('skip') ?? '0').trim()
+			const parsedSkip = /^\d+$/.test(rawSkip) ? Number(rawSkip) : Number.NaN
+			const skip = Number.isSafeInteger(parsedSkip) ? parsedSkip : 0
+			const rawTake = (c.req.query('take') ?? '100').trim()
+			const parsedTake = /^\d+$/.test(rawTake) ? Number(rawTake) : Number.NaN
+			const take = Number.isSafeInteger(parsedTake) && parsedTake > 0 ? parsedTake : 100
 			return c.json(await getBaseRooms(c.env.DB, skip, take))
 		}
 	)


### PR DESCRIPTION
## Summary
Strictly parse base-room `skip` and `take` values. Malformed numeric prefixes now use the existing defaults instead of being partially accepted.