### PR TITLE
[rooms] strictly parse room take queries

### DIFF
--- a/apps/rooms/src/rooms.app.ts
+++ b/apps/rooms/src/rooms.app.ts
@@ -832,7 +832,8 @@ const app = new Hono<App>()
 			responses: { 200: json(SearchSuggestions, 'The suggestions, best match first') },
 		}),
 		async (c) => {
-			const take = Number.parseInt(c.req.query('take') ?? '', 10)
+			const rawTake = (c.req.query('take') ?? '').trim()
+			const take = /^\d+$/.test(rawTake) ? Number(rawTake) : Number.NaN
 			return c.json(
 				await autocompleteRoomSearch(
 					c.env.DB,


### PR DESCRIPTION
## Summary
Reject partially numeric room `take` values on the remaining direct-pagination route. Invalid values preserve the route’s existing downstream/default behavior.