### PR TITLE
[lists] strictly serialize curated creator ids

### DIFF
--- a/apps/lists/src/curated-lists.ts
+++ b/apps/lists/src/curated-lists.ts
@@ -118,7 +118,11 @@ export function isReservedListName(name: string | undefined): boolean {
 function emptyReservedList(creatorAccountId: string | undefined, type: number, name: string) {
 	return {
 		ListId: '0',
-		CreatorAccountId: Number.parseInt(creatorAccountId ?? '', 10) || 0,
+		CreatorAccountId: (() => {
+			const raw = (creatorAccountId ?? '').trim()
+			const id = /^\d+$/.test(raw) ? Number(raw) : Number.NaN
+			return Number.isSafeInteger(id) ? id : 0
+		})(),
 		Name: name,
 		Description: null,
 		ImageName: DEFAULT_LIST_IMAGE,


### PR DESCRIPTION
## Summary
Stop curated-list response construction from partially parsing malformed creator account IDs. Invalid or unsafe values now serialize as the existing fallback `0`.