### PR TITLE
[rooms] implement my room role endpoint

### DIFF
--- a/apps/rooms/src/rooms.app.ts
+++ b/apps/rooms/src/rooms.app.ts
@@ -1942,6 +1942,40 @@ const app = new Hono<App>()
 		}
 	)
 
+	// Return the authenticated player's effective role in a room. This legacy route is
+	// used by the 2023 client when refreshing room permissions after a role change.
+	.get(
+		'/rooms/:roomId{[0-9]+}/roles/myrole',
+		describeRoute({
+			tags: ['Room settings'],
+			summary: 'Get my role in a room',
+			description:
+				'Returns the authenticated caller’s effective room role as a bare integer. 255 is the creator; explicit Room.Roles values are returned verbatim (30 co-owner, 20 moderator, 10 host/member); 0 means no explicit role.',
+			security: AUTHED,
+			parameters: [roomIdParam],
+			responses: {
+				200: { description: 'The caller’s room role as a bare integer' },
+				401: UNAUTHORIZED_RESPONSE,
+				404: { description: 'Room not found' },
+			},
+		}),
+		async (c) => {
+			const accountId = await authedAccountId(c)
+			if (accountId === null) return unauthorized(c)
+
+			const roomId = Number.parseInt(c.req.param('roomId'), 10)
+			const room = await getRoomById(c.env.DB, roomId)
+			if (!room) return c.body(null, 404)
+			if (room.CreatorAccountId === accountId) return c.json(255)
+
+			const roles = Array.isArray(room.Roles)
+				? (room.Roles as Array<{ AccountId?: unknown; Role?: unknown }>)
+				: []
+			const entry = roles.find((r) => r.AccountId === accountId && typeof r.Role === 'number')
+			return c.json(entry?.Role ?? 0)
+		}
+	)
+
 	// Set a member's role in a room (`Roles[].Role`). Auth-gated (401) and gated to
 	// the room creator or a co-owner (403 otherwise) — the same owner/co-owner check
 	// the other room-admin actions use. Body is the `role` form field (an integer role

--- a/apps/rooms/src/test/integration/api.test.ts
+++ b/apps/rooms/src/test/integration/api.test.ts
@@ -1629,6 +1629,29 @@ describe('rooms endpoints', () => {
 		expect(interactions!.n).toBe(0)
 	})
 
+	it('GET /rooms/:id/roles/myrole reports the caller’s effective legacy room role', async () => {
+		const myRole = async (roomId: number, accountId?: string) =>
+			SELF.fetch(`${ORIGIN}/rooms/${roomId}/roles/myrole`, {
+				headers: accountId ? await bearer(accountId) : undefined,
+			})
+
+		expect((await myRole(2)).status).toBe(401)
+
+		const owner = await myRole(2, '1')
+		expect(owner.status).toBe(200)
+		expect(await owner.json()).toBe(255)
+
+		const coOwner = await myRole(2, '2')
+		expect(coOwner.status).toBe(200)
+		expect(await coOwner.json()).toBe(30)
+
+		const ordinary = await myRole(2, '999')
+		expect(ordinary.status).toBe(200)
+		expect(await ordinary.json()).toBe(0)
+
+		expect((await myRole(99999, '1')).status).toBe(404)
+	})
+
 	it('PUT /rooms/:id/roles/:accountId is auth-gated, owner/co-owner-only, and persists', async () => {
 		const rolesOf = async (): Promise<Array<{ AccountId: number; Role: number }>> => {
 			const room = (await (await SELF.fetch(`${ORIGIN}/rooms/2`)).json()) as {

--- a/apps/rooms/src/test/integration/api.test.ts
+++ b/apps/rooms/src/test/integration/api.test.ts
@@ -4123,6 +4123,7 @@ describe('rooms endpoints', () => {
 			'GET /rooms/{roomId}/experience/player',
 			'GET /rooms/{roomId}/interactionby/me',
 			'GET /rooms/{roomId}/playerdata/me',
+			'GET /rooms/{roomId}/roles/myrole',
 			'GET /rooms/{roomId}/similar',
 			'GET /rooms/{roomId}/subrooms/{subRoomId}/saves',
 			'GET /rooms/{roomId}/subrooms/{subRoomId}/saves/no_unity_assets',


### PR DESCRIPTION
## Summary
Implement the legacy `GET /rooms/:roomId/roles/myrole` endpoint captured in RecFlare’s API research.

- auth-gated
- returns `255` for the room creator
- returns the caller’s explicit `Room.Roles` tier (30 co-owner, 20 moderator, 10 host/member)
- returns `0` when the caller has no explicit room role
- returns 404 for an unknown room
- adds regression coverage for auth, creator, co-owner, ordinary player and unknown-room behavior

## Why
OrangeVR users report that assigning co-owner does not fully take effect in-client. RecFlare already persists role changes and notifies the affected player, but the historical role-refresh endpoint was missing.